### PR TITLE
fix vpn errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ HEALTHCHECK --interval=60s --timeout=15s --start-period=120s \
 # This is where the configuration files will go.
 VOLUME [ "/vpn/config" ]
 
-CMD [ "openvpn", "--config", "/vpn/config/config.ovpn" ]
+CMD [ "openvpn", "--ncp-disable", "--dev tun", "--config", "/vpn/config/config.ovpn" ]


### PR DESCRIPTION
vpn_1_bcf7e057f4cb | Sun Dec 26 03:53:46 2021 disabling NCP mode (--ncp-disable) because not in P2MP client or server mode
vpn_1_bcf7e057f4cb | Options error: You must define TUN/TAP device (--dev)
vpn_1_bcf7e057f4cb | Use --help for more information.
flood_vpn_1_bcf7e057f4cb exited with code 1